### PR TITLE
Position pop-out windows near the tray icon when no pointer anchor

### DIFF
--- a/Trdo/App.xaml.cs
+++ b/Trdo/App.xaml.cs
@@ -145,6 +145,7 @@ public partial class App : Application
         _trayIcon.Selected += TrayIcon_Selected;
         _trayIcon.ContextMenu += TrayIcon_ContextMenu;
         _trayIcon.IsVisible = true;
+        WindowPlacementService.SetTrayIconSource(_trayIcon);
 
         // Only show tutorial window on first run
         if (SettingsService.IsFirstRun)

--- a/Trdo/Services/WindowPlacementService.cs
+++ b/Trdo/Services/WindowPlacementService.cs
@@ -1,5 +1,8 @@
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using System;
+using System.Globalization;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Windows.Graphics;
 using WinUIEx;
@@ -10,6 +13,9 @@ internal static partial class WindowPlacementService
 {
     private const int WindowMargin = 12;
     private static PointInt32? _lastAnchorPoint;
+    private static nint _trayIconWindowHandle;
+    private static uint _trayIconId;
+    private static bool _hasTrayIconSource;
 
     public static void CapturePointerAnchor()
     {
@@ -17,17 +23,94 @@ internal static partial class WindowPlacementService
             _lastAnchorPoint = new PointInt32(point.X, point.Y);
     }
 
+    public static void SetTrayIconSource(TrayIcon trayIcon)
+    {
+        if (TryGetTrayIconWindowHandle(trayIcon, out nint hwnd))
+        {
+            _trayIconWindowHandle = hwnd;
+            _trayIconId = trayIcon.TrayIconId;
+            _hasTrayIconSource = true;
+        }
+    }
+
     public static void PositionWindowNearAnchor(Window window, int width, int height)
     {
+        bool usePointerPlacement = _lastAnchorPoint is PointInt32;
         PointInt32 anchor = GetAnchorPoint();
         DisplayArea? displayArea = DisplayArea.GetFromPoint(anchor, DisplayAreaFallback.Nearest);
         RectInt32 workArea = displayArea?.WorkArea ?? DisplayArea.Primary.WorkArea;
 
-        bool placeLeft = anchor.X >= workArea.X + (workArea.Width / 2);
-        bool placeAbove = anchor.Y >= workArea.Y + (workArea.Height / 2);
+        int x;
+        int y;
 
-        int x = placeLeft ? anchor.X - width - WindowMargin : anchor.X + WindowMargin;
-        int y = placeAbove ? anchor.Y - height - WindowMargin : anchor.Y + WindowMargin;
+        if (usePointerPlacement)
+        {
+            bool placeLeft = anchor.X >= workArea.X + (workArea.Width / 2);
+            bool placeAbove = anchor.Y >= workArea.Y + (workArea.Height / 2);
+
+            x = placeLeft ? anchor.X - width - WindowMargin : anchor.X + WindowMargin;
+            y = placeAbove ? anchor.Y - height - WindowMargin : anchor.Y + WindowMargin;
+        }
+        else if (TryGetTrayIconRect(out RECT iconRect))
+        {
+            int iconCenterX = (iconRect.Left + iconRect.Right) / 2;
+            x = iconCenterX - (width / 2);
+
+            if (TryGetTaskbarRect(out RECT taskbarRect, out uint taskbarEdge))
+            {
+                y = taskbarEdge switch
+                {
+                    ABE_BOTTOM => taskbarRect.Top - height,
+                    ABE_TOP => taskbarRect.Bottom,
+                    _ => iconRect.Top >= workArea.Y + (workArea.Height / 2)
+                        ? iconRect.Top - height - WindowMargin
+                        : iconRect.Bottom + WindowMargin
+                };
+            }
+            else
+            {
+                bool iconOnBottomHalf = iconRect.Top >= workArea.Y + (workArea.Height / 2);
+                y = iconOnBottomHalf
+                    ? iconRect.Top - height - WindowMargin
+                    : iconRect.Bottom + WindowMargin;
+            }
+        }
+        else if (TryGetTaskbarRect(out RECT taskbarRect, out uint taskbarEdge))
+        {
+            bool isRtl = CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft;
+            int taskbarMidY = taskbarRect.Top + ((taskbarRect.Bottom - taskbarRect.Top) / 2);
+
+            x = taskbarEdge switch
+            {
+                ABE_BOTTOM or ABE_TOP => isRtl
+                    ? taskbarRect.Left + WindowMargin
+                    : taskbarRect.Right - WindowMargin - width,
+                _ => workArea.X + (workArea.Width / 2) - (width / 2)
+            };
+
+            y = taskbarEdge switch
+            {
+                ABE_BOTTOM => taskbarRect.Top - height,
+                ABE_TOP => taskbarRect.Bottom,
+                ABE_LEFT => taskbarMidY - (height / 2),
+                ABE_RIGHT => taskbarMidY - (height / 2),
+                _ => taskbarRect.Top - height
+            };
+
+            if (taskbarEdge is ABE_LEFT or ABE_RIGHT)
+            {
+                x = taskbarEdge == ABE_LEFT
+                    ? taskbarRect.Right + WindowMargin
+                    : taskbarRect.Left - width - WindowMargin;
+            }
+        }
+        else
+        {
+            bool placeAbove = anchor.Y >= workArea.Y + (workArea.Height / 2);
+
+            x = anchor.X - (width / 2);
+            y = placeAbove ? anchor.Y - height - WindowMargin : anchor.Y + WindowMargin;
+        }
 
         int maxX = System.Math.Max(workArea.X, workArea.X + workArea.Width - width);
         int maxY = System.Math.Max(workArea.Y, workArea.Y + workArea.Height - height);
@@ -43,14 +126,74 @@ internal static partial class WindowPlacementService
         if (_lastAnchorPoint is PointInt32 anchor)
             return anchor;
 
+        if (TryGetTrayIconAnchorPoint(out anchor))
+            return anchor;
+
         if (TryGetTaskbarAnchorPoint(out anchor))
             return anchor;
 
         RectInt32 workArea = DisplayArea.Primary.WorkArea;
-        return new PointInt32(workArea.X + workArea.Width - WindowMargin, workArea.Y + workArea.Height - WindowMargin);
+        return new PointInt32(
+            workArea.X + (workArea.Width / 2),
+            workArea.Y + workArea.Height - WindowMargin);
     }
 
-    private static bool TryGetTaskbarAnchorPoint(out PointInt32 anchor)
+    private static bool TryGetTrayIconAnchorPoint(out PointInt32 anchor)
+    {
+        if (!TryGetTrayIconRect(out RECT iconRect))
+        {
+            anchor = default;
+            return false;
+        }
+
+        anchor = new PointInt32(
+            (iconRect.Left + iconRect.Right) / 2,
+            (iconRect.Top + iconRect.Bottom) / 2);
+        return true;
+    }
+
+    private static bool TryGetTrayIconRect(out RECT iconRect)
+    {
+        iconRect = default;
+
+        if (!_hasTrayIconSource || _trayIconWindowHandle == 0)
+            return false;
+
+        NOTIFYICONIDENTIFIER identifier = new()
+        {
+            cbSize = Marshal.SizeOf<NOTIFYICONIDENTIFIER>(),
+            hWnd = _trayIconWindowHandle,
+            uID = _trayIconId,
+        };
+
+        return Shell_NotifyIconGetRect(ref identifier, out iconRect) == 0;
+    }
+
+    private static bool TryGetTrayIconWindowHandle(TrayIcon trayIcon, out nint hwnd)
+    {
+        hwnd = 0;
+
+        try
+        {
+            FieldInfo? field = typeof(TrayIcon).GetField(
+                "_windowHandle",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+
+            if (field?.GetValue(trayIcon) is nint handle && handle != 0)
+            {
+                hwnd = handle;
+                return true;
+            }
+        }
+        catch
+        {
+            // WinUIEx internals may change across versions
+        }
+
+        return false;
+    }
+
+    private static bool TryGetTaskbarRect(out RECT rc, out uint edge)
     {
         APPBARDATA appBarData = new()
         {
@@ -59,17 +202,44 @@ internal static partial class WindowPlacementService
 
         if (SHAppBarMessage(ABM_GETTASKBARPOS, ref appBarData) == 0)
         {
+            rc = default;
+            edge = 0;
+            return false;
+        }
+
+        rc = appBarData.rc;
+        edge = appBarData.uEdge;
+        return true;
+    }
+
+    private static bool TryGetTaskbarAnchorPoint(out PointInt32 anchor)
+    {
+        if (!TryGetTaskbarRect(out RECT taskbarRect, out uint edge))
+        {
             anchor = default;
             return false;
         }
 
-        anchor = appBarData.uEdge switch
+        bool isRtl = CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft;
+        int taskbarMidY = taskbarRect.Top + ((taskbarRect.Bottom - taskbarRect.Top) / 2);
+
+        anchor = edge switch
         {
-            ABE_BOTTOM => new PointInt32(appBarData.rc.Right - WindowMargin, appBarData.rc.Top + ((appBarData.rc.Bottom - appBarData.rc.Top) / 2)),
-            ABE_TOP => new PointInt32(appBarData.rc.Right - WindowMargin, appBarData.rc.Bottom - WindowMargin),
-            ABE_LEFT => new PointInt32(appBarData.rc.Right - WindowMargin, appBarData.rc.Bottom - WindowMargin),
-            ABE_RIGHT => new PointInt32(appBarData.rc.Left + WindowMargin, appBarData.rc.Bottom - WindowMargin),
-            _ => new PointInt32(appBarData.rc.Right - WindowMargin, appBarData.rc.Bottom - WindowMargin)
+            ABE_BOTTOM => new PointInt32(
+                isRtl ? taskbarRect.Left + WindowMargin : taskbarRect.Right - WindowMargin,
+                taskbarMidY),
+            ABE_TOP => new PointInt32(
+                isRtl ? taskbarRect.Left + WindowMargin : taskbarRect.Right - WindowMargin,
+                taskbarRect.Bottom - WindowMargin),
+            ABE_LEFT => new PointInt32(
+                taskbarRect.Right - WindowMargin,
+                taskbarRect.Bottom - WindowMargin),
+            ABE_RIGHT => new PointInt32(
+                taskbarRect.Left + WindowMargin,
+                taskbarRect.Bottom - WindowMargin),
+            _ => new PointInt32(
+                isRtl ? taskbarRect.Left + WindowMargin : taskbarRect.Right - WindowMargin,
+                taskbarRect.Bottom - WindowMargin)
         };
 
         return true;
@@ -98,6 +268,15 @@ internal static partial class WindowPlacementService
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    private struct NOTIFYICONIDENTIFIER
+    {
+        public int cbSize;
+        public nint hWnd;
+        public uint uID;
+        public Guid guidItem;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     private struct APPBARDATA
     {
         public int cbSize;
@@ -114,4 +293,7 @@ internal static partial class WindowPlacementService
 
     [LibraryImport("shell32.dll")]
     private static partial uint SHAppBarMessage(uint dwMessage, ref APPBARDATA pData);
+
+    [DllImport("shell32.dll", SetLastError = true)]
+    private static extern int Shell_NotifyIconGetRect(ref NOTIFYICONIDENTIFIER identifier, out RECT iconLocation);
 }


### PR DESCRIPTION

## Summary
- Position pop-out windows (`TutorialWindow`, `ManualStationWindow`) near the tray icon when no pointer anchor is available
- Use `Shell_NotifyIconGetRect` with the WinUIEx tray icon handle to locate the icon on screen
- Preserve existing cursor-relative placement when `CapturePointerAnchor()` was called (tray flyout flows)
- Improve taskbar-edge fallback placement and RTL awareness

Fixes #87

## Motivation
On first run, the tutorial window opens without a captured pointer position and currently lands far from the tray icon instead of adjacent to it. Reported on Hebrew (RTL) Windows 10 with a bottom taskbar.

## Test plan
- [ ] Reset app data (Settings → Apps → Trdo → Reset) and launch — tutorial opens above/near the tray icon
- [ ] Open tray flyout via right-click — still opens at cursor
- [ ] From flyout, open Manual Station window — still opens near cursor
- [ ] Taskbar on top / left / right — pop-out appears on the correct side
- [ ] RTL system locale — window anchors to the correct horizontal side



<img width="1791" height="643" alt="Screenshot_7" src="https://github.com/user-attachments/assets/15464bbc-1a9e-46a2-9257-845f615d7452" />

<img width="1053" height="658" alt="Screenshot_6" src="https://github.com/user-attachments/assets/ff31deca-8250-41f5-8566-8fb29ffa310d" />